### PR TITLE
Make accessibility optional and return iOS errors

### DIFF
--- a/ios/Plugin/SecureStoragePlugin.swift
+++ b/ios/Plugin/SecureStoragePlugin.swift
@@ -34,7 +34,7 @@ public class SecureStoragePlugin: CAPPlugin {
                 "value": true
             ])
         } catch {
-            call.reject("error")
+            call.reject("error: \(error)")
         }
     }
         
@@ -52,7 +52,7 @@ public class SecureStoragePlugin: CAPPlugin {
                 "value": value ?? ""
             ])
         } catch {
-            call.reject("error")
+            call.reject("error: \(error)")
         }
     }
     
@@ -85,7 +85,7 @@ public class SecureStoragePlugin: CAPPlugin {
             ])
         }
         catch {
-            call.reject("error")
+            call.reject("error: \(error)")
         }
     }
     
@@ -97,7 +97,7 @@ public class SecureStoragePlugin: CAPPlugin {
             ])
         }
         catch {
-            call.reject("error")
+            call.reject("error: \(error)")
         }
     }
     

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -19,7 +19,7 @@ export const accessibilityOptions: Accessibility[] = [
 export interface SetDataOptions {
   key: string
   value: string
-  accessibility: Accessibility
+  accessibility?: Accessibility
 }
 /**
  * The SecureStoragePlugin plugin interface


### PR DESCRIPTION
Hi @laszloblum,

I stumbled upon your fork and I think you made some great additions to the original plugin. I just have two small suggestions to make:
* As with the original plugin, errors on iOS just return the string 'error' which is not useful if they occur in production. I'm not really familiar with Swift but I assume what I added should include the original error message.
* The accessibility parameter has a default value in your implementation so I also marked it that way in the interface. This makes the method a bit more convenient to use.

Please let me know what you think of these changes.